### PR TITLE
Docs: /data 위치 설정, PIP_ADDITIONAL_REQUIREMENTS 추가

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,12 +72,13 @@ x-airflow-common:
     AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
-    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:- steamspypi apache-airflow-providers-amazon}
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+    - ${AIRFLOW_PROJ_DIR:-.}/data:/opt/airflow/data
     - ${AIRFLOW_PROJ_DIR:-.}/connections.json:/opt/airflow/connections.json
     - ${AIRFLOW_PROJ_DIR:-.}/variables.json:/opt/airflow/variables.json
   user: "${AIRFLOW_UID:-50000}:0"
@@ -248,7 +249,7 @@ services:
           echo "   https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#before-you-begin"
           echo
         fi
-        mkdir -p /sources/logs /sources/dags /sources/plugins
+        mkdir -p /sources/logs /sources/dags /sources/plugins /sources/data
         chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
         exec /entrypoint airflow version
     # yamllint enable rule:line-length


### PR DESCRIPTION
-  _PIP_ADDITIONAL_REQUIREMENTS: steamspypi, apache-airflow-providers-amazon 모듈 추가
-  /data: /opt/airflow/data로 설정 
- airflow-init command에서도 mkdir /source/data 세팅